### PR TITLE
Adding more URI objects

### DIFF
--- a/benchmarks/AuraUriBench.php
+++ b/benchmarks/AuraUriBench.php
@@ -17,6 +17,6 @@ class AuraUriBench extends AbstractBench
 
     public function benchCreateValueObject()
     {
-        $url = $this->factory->newInstance($this->getUrlString());
+        $this->factory->newInstance($this->getUrlString());
     }
 }

--- a/benchmarks/DiactorosUriBench.php
+++ b/benchmarks/DiactorosUriBench.php
@@ -2,14 +2,12 @@
 
 namespace PhpBench\Benchmarks;
 
-use Windwalker\Uri\Uri;
+use Zend\Diactoros\Uri;
 
-
-class WindwalkerUriBench extends AbstractBench
+class DiactorosUriBench extends AbstractBench
 {
     public function benchCreateValueObject()
     {
         new Uri($this->getUrlString());
     }
 }
-

--- a/benchmarks/GuzzlePsr7UriBench.php
+++ b/benchmarks/GuzzlePsr7UriBench.php
@@ -2,14 +2,12 @@
 
 namespace PhpBench\Benchmarks;
 
-use Windwalker\Uri\Uri;
+use GuzzleHttp\Psr7\Uri;
 
-
-class WindwalkerUriBench extends AbstractBench
+class GuzzlePsr7UriBench extends AbstractBench
 {
     public function benchCreateValueObject()
     {
         new Uri($this->getUrlString());
     }
 }
-

--- a/benchmarks/LeagueUriBench.php
+++ b/benchmarks/LeagueUriBench.php
@@ -8,8 +8,6 @@ class LeagueUriBench extends AbstractBench
 {
     public function benchCreateValueObject()
     {
-        $uri = Http::createFromString($this->getUrlString());
-        $uri->getScheme();
-        $uri->getAuthority();
+        Http::createFromComponents(parse_url($this->getUrlString()));
     }
 }

--- a/benchmarks/NetUrl2Bench.php
+++ b/benchmarks/NetUrl2Bench.php
@@ -8,6 +8,6 @@ class NetUrl2Bench extends AbstractBench
 {
     public function benchCreateValueObject()
     {
-        $url = new Net_URL2($this->getUrlString());
+        new Net_URL2($this->getUrlString());
     }
 }

--- a/benchmarks/SlimUriBench.php
+++ b/benchmarks/SlimUriBench.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PhpBench\Benchmarks;
+
+use Slim\Http\Uri;
+
+class SlimUriBench extends AbstractBench
+{
+    public function benchCreateValueObject()
+    {
+        Uri::createFromString($this->getUrlString());
+    }
+}

--- a/benchmarks/VdbUriBench.php
+++ b/benchmarks/VdbUriBench.php
@@ -8,6 +8,6 @@ class VdbUriBench extends AbstractBench
 {
     public function benchCreateValueObject()
     {
-        $uri = new Uri($this->getUrlString());
+        new Uri($this->getUrlString());
     }
 }

--- a/benchmarks/ZendUriBench.php
+++ b/benchmarks/ZendUriBench.php
@@ -8,6 +8,6 @@ class ZendUriBench extends AbstractBench
 {
     public function benchCreateValueObject()
     {
-        $uri = new Uri($this->getUrlString());
+        new Uri($this->getUrlString());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,13 @@
     "require": {
         "pear/net_url2": "~2.0",
         "zendframework/zend-uri": "~2.5",
-        "league/uri": "~4.0",
         "windwalker/uri": "~3.0",
         "vdb/uri": "^0.2.0",
-        "aura/uri": "^1.2"
+        "aura/uri": "^1.2",
+        "zendframework/zend-diactoros": "^1.3",
+        "guzzlehttp/psr7": "^1.3",
+        "slim/slim": "^3.6",
+        "league/uri-schemes": "^0.3.0"
     },
     "require-dev": {
         "phpbench/phpbench": "~0.12"


### PR DESCRIPTION
 League URI is intended to be used as a PSR-7 URI object. I've added the most used PSR-7 Uri objects to the bench namely:

- [Diactoros URI](https://github.com/zendframework/zend-diactoros/blob/master/src/Uri.php)
- [Guzzle URI](https://github.com/guzzle/psr7/blob/master/src/Uri.php)
- [Slim URI](https://github.com/slimphp/Slim/blob/3.x/Slim/Http/Uri.php)

League URI v4 is slow, so I've added the new version in work which is faster.
By default League URI uses it's own parser to be sure we are testing the same thing the test is done using `Uri::createFromComponents` to be sure that we are comparing the same overhead since all PSR-7 Uri objects uses internally `parse_url`